### PR TITLE
Fix frontend Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - NEXT_PUBLIC_INTERNAL_API_URL=http://django:8000/api/v1
     depends_on:
       - django
-    command: yarn dev
+    command: npm run dev
     restart: on-failure
 
 volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,8 +4,8 @@ FROM node:18-alpine
 WORKDIR /app
 
 # Install dependencies
-COPY package.json yarn.lock* ./
-RUN yarn install --frozen-lockfile
+COPY package.json package-lock.json* ./
+RUN npm ci
 
 # Copy app files
 COPY . .
@@ -14,4 +14,4 @@ COPY . .
 EXPOSE 3000
 
 # Start the app
-CMD ["yarn", "dev"] 
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## Summary
- fix frontend Dockerfile to use npm
- update docker-compose to call npm instead of yarn

## Testing
- `npm run lint` *(fails: next not found before install)*
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68417b04a5a8832c914cac1c8c7c07a1