### PR TITLE
Parse settings from env

### DIFF
--- a/backend/blog/settings.py
+++ b/backend/blog/settings.py
@@ -19,7 +19,12 @@ SECRET_KEY = env('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env('DEBUG')
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0', 'django']
+# Hosts/domain names that are valid for this site
+# https://docs.djangoproject.com/en/stable/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = env.list(
+    'DJANGO_ALLOWED_HOSTS',
+    default=['localhost', '127.0.0.1', '0.0.0.0', 'django'],
+)
 
 # Application definition
 INSTALLED_APPS = [
@@ -136,11 +141,14 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'mediafiles')
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # CORS settings
-CORS_ALLOWED_ORIGINS = [
-    'http://localhost:3000',
-    'http://127.0.0.1:3000',
-    'http://django:8000',
-]
+CORS_ALLOWED_ORIGINS = env.list(
+    'CORS_ALLOWED_ORIGINS',
+    default=[
+        'http://localhost:3000',
+        'http://127.0.0.1:3000',
+        'http://django:8000',
+    ],
+)
 
 # REST Framework settings
 REST_FRAMEWORK = {


### PR DESCRIPTION
## Summary
- parse `ALLOWED_HOSTS` from `DJANGO_ALLOWED_HOSTS`
- parse `CORS_ALLOWED_ORIGINS` from `CORS_ALLOWED_ORIGINS`

## Testing
- `python -m py_compile backend/blog/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_684183af7790832c8ca76f579f09852f