### PR TITLE
Add ENV_FILE config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,11 @@ Changes to the frontend code will automatically trigger a hot reload.
 For production deployment:
 
 1. Create a `.env.prod` file with your production values (set `DEBUG=False` and update database, cache, and allowed host settings).
-2. Build and run the containers with production configuration:
+2. Set the `ENV_FILE` environment variable so Django reads the correct file:
+   ```bash
+   export ENV_FILE=.env.prod
+   ```
+3. Build and run the containers with production configuration:
    ```bash
    docker-compose -f docker-compose.prod.yml up -d
    ```

--- a/backend/blog/settings.py
+++ b/backend/blog/settings.py
@@ -10,8 +10,9 @@ env = environ.Env(
 # Build paths inside the project
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Take environment variables from .env file
-environ.Env.read_env(os.path.join(BASE_DIR.parent, '.env.dev'))
+# Take environment variables from the file specified by ENV_FILE
+env_file = os.environ.get('ENV_FILE', '.env.dev')
+environ.Env.read_env(os.path.join(BASE_DIR.parent, env_file))
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env('SECRET_KEY')

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -6,6 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
+    os.environ.setdefault('ENV_FILE', '.env.dev')
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'blog.settings')
     try:
         from django.core.management import execute_from_command_line

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: Dockerfile
     env_file:
       - ./.env.prod
+    environment:
+      - ENV_FILE=.env.prod
     volumes:
       - static_volume:/app/staticfiles
       - media_volume:/app/mediafiles
@@ -24,6 +26,8 @@ services:
       - postgres_data:/var/lib/postgresql/data/
     env_file:
       - ./.env.prod
+    environment:
+      - ENV_FILE=.env.prod
     restart: unless-stopped
 
   redis:
@@ -37,6 +41,8 @@ services:
     command: celery -A blog worker -l INFO
     env_file:
       - ./.env.prod
+    environment:
+      - ENV_FILE=.env.prod
     depends_on:
       - django
       - redis
@@ -49,6 +55,8 @@ services:
     command: celery -A blog beat -l INFO
     env_file:
       - ./.env.prod
+    environment:
+      - ENV_FILE=.env.prod
     depends_on:
       - celery
       - redis
@@ -64,6 +72,7 @@ services:
     environment:
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
       - NEXT_PUBLIC_INTERNAL_API_URL=http://django:8000/api/v1
+      - ENV_FILE=.env.prod
     depends_on:
       - django
     command: sh -c "npm run build && npm start"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - media_volume:/app/mediafiles
     env_file:
       - ./.env.dev
+    environment:
+      - ENV_FILE=.env.dev
     depends_on:
       - db
       - redis
@@ -28,6 +30,8 @@ services:
       - postgres_data:/var/lib/postgresql/data/
     env_file:
       - ./.env.dev
+    environment:
+      - ENV_FILE=.env.dev
     ports:
       - "5432:5432"
     restart: on-failure
@@ -49,6 +53,8 @@ services:
       - ./backend:/app
     env_file:
       - ./.env.dev
+    environment:
+      - ENV_FILE=.env.dev
     depends_on:
       - django
       - redis
@@ -64,6 +70,8 @@ services:
       - ./backend:/app
     env_file:
       - ./.env.dev
+    environment:
+      - ENV_FILE=.env.dev
     depends_on:
       - celery
       - redis
@@ -85,6 +93,7 @@ services:
     environment:
       - NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1
       - NEXT_PUBLIC_INTERNAL_API_URL=http://django:8000/api/v1
+      - ENV_FILE=.env.dev
     depends_on:
       - django
     command: npm run dev


### PR DESCRIPTION
## Summary
- load env vars from file defined in `ENV_FILE` (default `.env.dev`)
- set default `ENV_FILE` in `manage.py`
- set `ENV_FILE` for Docker services
- document using `ENV_FILE=.env.prod` for production

## Testing
- `python backend/manage.py check` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_6841897195b8832c8ba10868e4b52be4