### PR TITLE
Add production env example

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,27 @@
+# Django settings
+DEBUG=False
+SECRET_KEY=replace_with_your_secret_key
+DJANGO_ALLOWED_HOSTS=yourdomain.com www.yourdomain.com
+
+# Database
+POSTGRES_DB=blog_db
+POSTGRES_USER=blog_user
+POSTGRES_PASSWORD=blog_password
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+DATABASE_URL=postgres://blog_user:blog_password@db:5432/blog_db
+
+# Redis & Celery
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_URL=redis://redis:6379/0
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0
+
+# CORS
+CORS_ALLOWED_ORIGINS=https://yourdomain.com
+
+# Next.js configuration
+NEXT_PUBLIC_SITE_URL=https://yourdomain.com
+NEXT_PUBLIC_API_URL=https://yourdomain.com/api/v1
+NEXT_PUBLIC_DEFAULT_OG_IMAGE=https://yourdomain.com/path/to/default-og-image.jpg

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ A modern, minimalist blog template built with Django, Docker, and Next.js. The t
    ```bash
    # Copy the example environment file for development
    cp .env.example .env.dev
-   # Copy the example environment file for production
-   cp .env.example .env.prod
+   # Copy the production example environment file
+   cp .env.prod.example .env.prod
    # Edit the .env.dev and .env.prod files as needed
    ```
 
@@ -57,7 +57,7 @@ A modern, minimalist blog template built with Django, Docker, and Next.js. The t
 - `frontend/`: Next.js frontend
 - `docker-compose.yml`: Docker Compose configuration
 - `.env.dev`: Development environment variables
-- `.env.prod`: Production environment variables (copy from `.env.example` and customize)
+- `.env.prod`: Production environment variables (copy from `.env.prod.example` and customize)
 - Temporary test files (`frontend/pages/index.test.tsx`, `frontend/components/IntersectionObserverTest.js`) and a stale `performance.json` were removed.
 
 ## Development Workflow
@@ -91,7 +91,7 @@ Changes to the frontend code will automatically trigger a hot reload.
 
 For production deployment:
 
-1. Create a `.env.prod` file with your production values (set `DEBUG=False` and update database, cache, and allowed host settings).
+1. Create a `.env.prod` file from `.env.prod.example` with your production values (set `DEBUG=False` and update database, cache, and allowed host settings).
 2. Build and run the containers with production configuration:
    ```bash
    docker-compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
## Summary
- add a `.env.prod.example` template listing required production variables
- update README to reference `.env.prod.example` for production setup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68418984ef84832c8fbdd9f6daef2fb9