### PR TITLE
Fix summernote version

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,5 +16,5 @@ whitenoise==6.6.0
 django-environ==0.11.2
 django-admin-interface==0.30.0
 django-colorfield==0.14.0
-django-summernote
+django-summernote==0.8.20.0
 django-imagekit==4.1.0 


### PR DESCRIPTION
## Summary
- pin `django-summernote` version in backend requirements

## Testing
- `python -m venv venv && . venv/bin/activate && pip install -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684189861c00832c828a683f1b2088a3