### PR TITLE
Remove verbose logs from core components

### DIFF
--- a/frontend/components/CategoryNavBar.tsx
+++ b/frontend/components/CategoryNavBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { getCategories, CategoryData } from '../lib/api';
+import { devLog } from '../lib/logger';
 
 interface CategoryNavBarProps {
   onCategorySelect: (slug: string | null) => void;
@@ -19,11 +20,11 @@ const CategoryNavBar: React.FC<CategoryNavBarProps> = ({
   // Fetch categories on component mount
   useEffect(() => {
     const fetchCategories = async () => {
-      console.log("🔍 [NavBar] fetching categories…");
+      devLog('🔍 [NavBar] fetching categories…');
       try {
         setIsLoading(true);
         const data = await getCategories();
-        console.log("✅ [NavBar] fetched categories:", data);
+        devLog('✅ [NavBar] fetched categories:', data);
         setCategories(data);
         setError(null);
       } catch (err) {

--- a/frontend/components/FeaturedPosts.tsx
+++ b/frontend/components/FeaturedPosts.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { Post } from './PostCard';
 import PostCardSkeleton from './PostCardSkeleton';
 import { getOptimizedImageUrl } from '../lib/utils';
+import { devLog } from '../lib/logger';
 
 interface FeaturedPostsProps {
   posts: Post[];
@@ -62,7 +63,7 @@ const FeaturedPosts: React.FC<FeaturedPostsProps> = ({ posts, isLoading, error }
     return null;
   }
 
-  console.log(`[FeaturedPosts] Rendering ${posts.length} featured posts`);
+  devLog(`[FeaturedPosts] Rendering ${posts.length} featured posts`);
 
   return (
     <section className="mb-12">
@@ -70,11 +71,11 @@ const FeaturedPosts: React.FC<FeaturedPostsProps> = ({ posts, isLoading, error }
       
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {posts.map((post) => {
-          console.log(`[FeaturedPosts] Processing post ${post.id}, with image ${post.featured_image}`);
+          devLog(`[FeaturedPosts] Processing post ${post.id}, with image ${post.featured_image}`);
           
           // Get optimized image URL
           const optimizedImageUrl = getOptimizedImageUrl(post.featured_image);
-          console.log(`[FeaturedPosts] Optimized URL for post ${post.id}: ${optimizedImageUrl}`);
+          devLog(`[FeaturedPosts] Optimized URL for post ${post.id}: ${optimizedImageUrl}`);
           
           return (
             <Link 

--- a/frontend/components/PostCard.tsx
+++ b/frontend/components/PostCard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { getOptimizedImageUrl } from '../lib/utils';
+import { devLog } from '../lib/logger';
 
 export interface Post {
   id: number;
@@ -39,8 +40,8 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
   const [formattedDate, setFormattedDate] = useState<string>('');
 
   useEffect(() => {
-    console.log(`[PostCard] Post ID: ${post.id}, Title: ${post.title}`);
-    console.log(`[PostCard] Original featured_image URL: ${post.featured_image}`);
+    devLog(`[PostCard] Post ID: ${post.id}, Title: ${post.title}`);
+    devLog(`[PostCard] Original featured_image URL: ${post.featured_image}`);
     
     // Format the date on the client side only
     const date = new Date(post.published_at);
@@ -57,9 +58,9 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
   const blurDataURL = post.blur_data_url || FALLBACK_BLUR_PLACEHOLDER;
   
   // Get optimized image URL
-  console.log(`[PostCard] Getting optimized URL for post ${post.id}`);
+  devLog(`[PostCard] Getting optimized URL for post ${post.id}`);
   const optimizedImageUrl = getOptimizedImageUrl(post.featured_image);
-  console.log(`[PostCard] Final optimized URL for image: ${optimizedImageUrl}`);
+  devLog(`[PostCard] Final optimized URL for image: ${optimizedImageUrl}`);
 
   // Create the post URL for the Link component
   const postUrl = `/posts/${post.slug}`;

--- a/frontend/components/PostGrid.tsx
+++ b/frontend/components/PostGrid.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PostCard, { Post } from './PostCard';
 import PostSkeletonGrid from './PostSkeletonGrid';
 import { getPosts } from '../lib/api';
+import { devLog } from '../lib/logger';
 
 interface PostGridProps {
   initialPosts: Post[];
@@ -48,7 +49,7 @@ const PostGrid: React.FC<PostGridProps> = ({
     const fetchInitialPosts = async () => {
       try {
         setIsLoading(true);
-        console.log(`Fetching initial posts for category: ${category}, search: ${search}`);
+        devLog(`Fetching initial posts for category: ${category}, search: ${search}`);
         
         const result = await getPosts(1, pageSize, category, search);
         

--- a/frontend/lib/logger.ts
+++ b/frontend/lib/logger.ts
@@ -1,0 +1,6 @@
+export const devLog = (...args: unknown[]): void => {
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  }
+};


### PR DESCRIPTION
## Summary
- add `devLog` helper to log only in development
- replace `console.log` calls with `devLog` in CategoryNavBar, FeaturedPosts, PostCard and PostGrid

## Testing
- `npm run lint` *(fails: errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68418987aac8832c92810ed0f2044c45