### PR TITLE
Fix Unsplash remote pattern

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -29,7 +29,7 @@ module.exports = {
       },
       {
         protocol: 'https',
-        hostname: '**.unsplash.com',
+        hostname: '*.unsplash.com',
       },
       {
         protocol: 'https',


### PR DESCRIPTION
## Summary
- fix wildcard for Unsplash images in `next.config.js`

## Testing
- `npm run lint` *(fails: no-unused-vars and other lint errors)*
- `curl -L -o /tmp/img.jpg https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68419b4a49e8832c9254e37bf8566e51