### PR TITLE
Wrap frontend logs in dev checks

### DIFF
--- a/frontend/components/HeroSection.tsx
+++ b/frontend/components/HeroSection.tsx
@@ -3,6 +3,8 @@ import Image from 'next/image';
 import { ThemeData } from '../lib/api';
 import { getOptimizedImageUrl } from '../lib/utils';
 
+const isDev = process.env.NODE_ENV === 'development';
+
 interface HeroSectionProps {
   theme: ThemeData | null;
   title: string;
@@ -31,11 +33,15 @@ const HeroSection: React.FC<HeroSectionProps> = ({
     );
   }
 
-  console.log(`[HeroSection] Original hero image URL: ${theme.hero_image}`);
+  if (isDev) {
+    console.log(`[HeroSection] Original hero image URL: ${theme.hero_image}`);
+  }
   
   // Get optimized image URL for the hero image
   const optimizedHeroImageUrl = getOptimizedImageUrl(theme.hero_image);
-  console.log(`[HeroSection] Optimized hero image URL: ${optimizedHeroImageUrl}`);
+  if (isDev) {
+    console.log(`[HeroSection] Optimized hero image URL: ${optimizedHeroImageUrl}`);
+  }
 
   return (
     <div className="relative h-80 sm:h-96 md:h-[500px] w-full mb-12 overflow-hidden">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,20 +1,28 @@
 import { Post } from '../components/PostCard';
 
+const isDev = process.env.NODE_ENV === 'development';
+
 // Determine execution environment (server/container vs browser)
 const isServer = typeof window === 'undefined';
-console.log(`[API] isServer: ${isServer}`);
+if (isDev) {
+  console.log(`[API] isServer: ${isServer}`);
+}
 
 // Use different base URLs depending on where code is executing
 const API_URL = isServer
   ? process.env.NEXT_PUBLIC_INTERNAL_API_URL || 'http://django:8000/api/v1'
   : process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
-console.log(`[API] Using API_URL: ${API_URL}`);
+if (isDev) {
+  console.log(`[API] Using API_URL: ${API_URL}`);
+}
 
 // Derive the base URL for media assets (remove '/api/v1' from API_URL)
 const MEDIA_BASE_URL = isServer
   ? (process.env.NEXT_PUBLIC_INTERNAL_API_URL || 'http://django:8000').replace(/\/api\/v1\/?$/, '')
   : (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000').replace(/\/api\/v1\/?$/, '');
-console.log(`[API] Using MEDIA_BASE_URL: ${MEDIA_BASE_URL}`);
+if (isDev) {
+  console.log(`[API] Using MEDIA_BASE_URL: ${MEDIA_BASE_URL}`);
+}
 
 /**
  * Helper function to transform relative image URLs to absolute URLs
@@ -36,19 +44,31 @@ function transformPostImageUrls(post: Post): Post {
   if (post.featured_image) {
     const originalUrl = post.featured_image;
     post.featured_image = transformImageUrl(post.featured_image);
-    console.log(`[API:transform] Post ${post.id} featured_image: ${originalUrl} -> ${post.featured_image}`);
+    if (isDev) {
+      console.log(
+        `[API:transform] Post ${post.id} featured_image: ${originalUrl} -> ${post.featured_image}`
+      );
+    }
   }
   
   if (post.side_image_1) {
     const originalUrl = post.side_image_1;
     post.side_image_1 = transformImageUrl(post.side_image_1);
-    console.log(`[API:transform] Post ${post.id} side_image_1: ${originalUrl} -> ${post.side_image_1}`);
+    if (isDev) {
+      console.log(
+        `[API:transform] Post ${post.id} side_image_1: ${originalUrl} -> ${post.side_image_1}`
+      );
+    }
   }
   
   if (post.side_image_2) {
     const originalUrl = post.side_image_2;
     post.side_image_2 = transformImageUrl(post.side_image_2);
-    console.log(`[API:transform] Post ${post.id} side_image_2: ${originalUrl} -> ${post.side_image_2}`);
+    if (isDev) {
+      console.log(
+        `[API:transform] Post ${post.id} side_image_2: ${originalUrl} -> ${post.side_image_2}`
+      );
+    }
   }
   
   return post;
@@ -78,7 +98,9 @@ export async function getFeaturedPosts(category?: string | null): Promise<Post[]
       url += `?category=${encodeURIComponent(category)}`;
     }
     
-    console.log(`[API:getFeaturedPosts] Fetching from ${url}`);
+    if (isDev) {
+      console.log(`[API:getFeaturedPosts] Fetching from ${url}`);
+    }
     const response = await fetch(url);
     
     if (!response.ok) {
@@ -89,12 +111,16 @@ export async function getFeaturedPosts(category?: string | null): Promise<Post[]
     // Some endpoints might wrap results in { results: [] }
     const results = Array.isArray(data) ? data : data.results || [];
     
-    console.log(`[API:getFeaturedPosts] Got ${results.length} posts${category ? ` for category ${category}` : ''}`);
+    if (isDev) {
+      console.log(
+        `[API:getFeaturedPosts] Got ${results.length} posts${category ? ` for category ${category}` : ''}`
+      );
+    }
     
     // Transform image URLs in all posts
     const transformedResults = results.map((post: Post) => transformPostImageUrls(post));
     
-    if (transformedResults.length > 0) {
+    if (transformedResults.length > 0 && isDev) {
       console.log(`[API:getFeaturedPosts] Sample transformed image URLs:`, {
         post_id: transformedResults[0].id,
         featured_image: transformedResults[0].featured_image
@@ -113,7 +139,9 @@ export async function getFeaturedPosts(category?: string | null): Promise<Post[]
  */
 export async function getActiveTheme(): Promise<ThemeData | null> {
   try {
-    console.log(`[API:getActiveTheme] Fetching from ${API_URL}/theme/`);
+    if (isDev) {
+      console.log(`[API:getActiveTheme] Fetching from ${API_URL}/theme/`);
+    }
     const response = await fetch(`${API_URL}/theme/`);
     if (!response.ok) {
       throw new Error(`Error fetching theme data: ${response.status}`);
@@ -121,11 +149,15 @@ export async function getActiveTheme(): Promise<ThemeData | null> {
     
     // Parse and transform hero_image to full URL for remote loading
     const data = (await response.json()) as ThemeData;
-    console.log(`[API:getActiveTheme] Original hero_image: ${data.hero_image}`);
+    if (isDev) {
+      console.log(`[API:getActiveTheme] Original hero_image: ${data.hero_image}`);
+    }
     
     if (data.hero_image) {
       data.hero_image = transformImageUrl(data.hero_image);
-      console.log(`[API:getActiveTheme] Transformed hero_image: ${data.hero_image}`);
+      if (isDev) {
+        console.log(`[API:getActiveTheme] Transformed hero_image: ${data.hero_image}`);
+      }
     }
     
     return data;
@@ -160,7 +192,9 @@ export async function getPosts(
     if (search) {
       url += `&search=${encodeURIComponent(search)}`;
     }
-    console.log(`[API:getPosts] Fetching from ${url}`);
+    if (isDev) {
+      console.log(`[API:getPosts] Fetching from ${url}`);
+    }
     
     const response = await fetch(url);
     
@@ -171,12 +205,16 @@ export async function getPosts(
     const data = await response.json();
     const results = Array.isArray(data) ? data : data.results || [];
     
-    console.log(`[API:getPosts] Got ${results.length} posts, hasMore: ${!!data.next}, total: ${data.count || results.length}`);
+    if (isDev) {
+      console.log(
+        `[API:getPosts] Got ${results.length} posts, hasMore: ${!!data.next}, total: ${data.count || results.length}`
+      );
+    }
     
     // Transform image URLs in all posts
     const transformedResults = results.map((post: Post) => transformPostImageUrls(post));
     
-    if (transformedResults.length > 0) {
+    if (transformedResults.length > 0 && isDev) {
       console.log(`[API:getPosts] Sample transformed image URLs:`, {
         post_id: transformedResults[0].id,
         featured_image: transformedResults[0].featured_image
@@ -200,28 +238,34 @@ export async function getPosts(
 
 export async function getPost(slug: string): Promise<Post | null> {
   try {
-    console.log(`[API:getPost] Fetching post ${slug} from ${API_URL}/posts/${slug}/`);
+    if (isDev) {
+      console.log(`[API:getPost] Fetching post ${slug} from ${API_URL}/posts/${slug}/`);
+    }
     const response = await fetch(`${API_URL}/posts/${slug}/`);
     if (!response.ok) {
       if (response.status === 404) return null;
       throw new Error(`Error fetching post: ${response.status}`);
     }
     const post = await response.json() as Post;
-    console.log(`[API:getPost] Got post ${post.id} - ${post.title}`);
-    console.log(`[API:getPost] Original image URLs:`, {
-      featured_image: post.featured_image,
-      side_image_1: post.side_image_1,
-      side_image_2: post.side_image_2
-    });
+    if (isDev) {
+      console.log(`[API:getPost] Got post ${post.id} - ${post.title}`);
+      console.log(`[API:getPost] Original image URLs:`, {
+        featured_image: post.featured_image,
+        side_image_1: post.side_image_1,
+        side_image_2: post.side_image_2
+      });
+    }
     
     // Transform image URLs
     const transformedPost = transformPostImageUrls(post);
-    
-    console.log(`[API:getPost] Transformed image URLs:`, {
-      featured_image: transformedPost.featured_image,
-      side_image_1: transformedPost.side_image_1,
-      side_image_2: transformedPost.side_image_2
-    });
+
+    if (isDev) {
+      console.log(`[API:getPost] Transformed image URLs:`, {
+        featured_image: transformedPost.featured_image,
+        side_image_1: transformedPost.side_image_1,
+        side_image_2: transformedPost.side_image_2
+      });
+    }
     
     return transformedPost;
   } catch (error) {

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -5,6 +5,8 @@
 // Site URL from environment variable with fallback
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
 
+const isDev = process.env.NODE_ENV === 'development';
+
 /**
  * Ensures image URLs are properly formatted for Next.js Image optimization
  * 
@@ -20,27 +22,37 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
  * @returns Properly formatted image URL
  */
 export function getOptimizedImageUrl(url: string | null): string {
-  console.log(`[getOptimizedImageUrl] Input URL: ${url}`);
+  if (isDev) {
+    console.log(`[getOptimizedImageUrl] Input URL: ${url}`);
+  }
   
   if (!url) {
-    console.log('[getOptimizedImageUrl] Empty URL, returning empty string');
+    if (isDev) {
+      console.log('[getOptimizedImageUrl] Empty URL, returning empty string');
+    }
     return '';
   }
   
   // Check if we're running on the server or client
   const isServer = typeof window === 'undefined';
-  console.log(`[getOptimizedImageUrl] Is Server: ${isServer}`);
+  if (isDev) {
+    console.log(`[getOptimizedImageUrl] Is Server: ${isServer}`);
+  }
   
   let finalUrl = url;
   
   // Fix any malformed URL protocols first (missing double slash)
   if (url.includes('https:/') && !url.includes('https://')) {
     finalUrl = url.replace(/https:\/([^\/])/g, 'https://$1');
-    console.log(`[getOptimizedImageUrl] Fixed malformed https URL: ${finalUrl}`);
+    if (isDev) {
+      console.log(`[getOptimizedImageUrl] Fixed malformed https URL: ${finalUrl}`);
+    }
   }
   if (url.includes('http:/') && !url.includes('http://')) {
     finalUrl = url.replace(/http:\/([^\/])/g, 'http://$1');
-    console.log(`[getOptimizedImageUrl] Fixed malformed http URL: ${finalUrl}`);
+    if (isDev) {
+      console.log(`[getOptimizedImageUrl] Fixed malformed http URL: ${finalUrl}`);
+    }
   }
   
   // Check for encoded external URLs (like http://django:8000/media/https%3A/picsum.photos/...)
@@ -50,7 +62,9 @@ export function getOptimizedImageUrl(url: string | null): string {
     // Try to extract and decode the actual external URL
     const decodedUrl = decodeURIComponent(encodedPart.replace(/%3A/g, ':'));
     if (decodedUrl.startsWith('http')) {
-      console.log(`[getOptimizedImageUrl] Detected encapsulated external URL: ${decodedUrl}`);
+      if (isDev) {
+        console.log(`[getOptimizedImageUrl] Detected encapsulated external URL: ${decodedUrl}`);
+      }
       
       // Fix the common issue with https:/picsum.photos -> https://picsum.photos
       let fixedUrl = decodedUrl;
@@ -66,11 +80,15 @@ export function getOptimizedImageUrl(url: string | null): string {
   }
   // If still looks like a Django-wrapped external URL after failed decoding
   else if (finalUrl.includes('/media/http')) {
-    console.log(`[getOptimizedImageUrl] Potential encapsulated URL detected: ${finalUrl}`);
+    if (isDev) {
+      console.log(`[getOptimizedImageUrl] Potential encapsulated URL detected: ${finalUrl}`);
+    }
     // Try to extract anything that looks like an URL after /media/
     const matches = finalUrl.match(/\/media\/(https?:\/\/.+)/i);
     if (matches && matches[1]) {
-      console.log(`[getOptimizedImageUrl] Extracted encapsulated URL: ${matches[1]}`);
+      if (isDev) {
+        console.log(`[getOptimizedImageUrl] Extracted encapsulated URL: ${matches[1]}`);
+      }
       
       // Fix URL if needed
       let extractedUrl = matches[1];
@@ -86,7 +104,9 @@ export function getOptimizedImageUrl(url: string | null): string {
   }
   // If it's already an absolute URL
   else if (finalUrl.startsWith('http')) {
-    console.log('[getOptimizedImageUrl] URL is already absolute');
+    if (isDev) {
+      console.log('[getOptimizedImageUrl] URL is already absolute');
+    }
     
     // If we're on the server and URL contains localhost:8000, replace with django:8000
     if (isServer && (
@@ -95,7 +115,9 @@ export function getOptimizedImageUrl(url: string | null): string {
       finalUrl.includes('[::1]:8000')
     )) {
       finalUrl = finalUrl.replace(/https?:\/\/(localhost|127\.0\.0\.1|\[::1\]):8000/g, 'http://django:8000');
-      console.log(`[getOptimizedImageUrl] Replaced localhost with django: ${finalUrl}`);
+      if (isDev) {
+        console.log(`[getOptimizedImageUrl] Replaced localhost with django: ${finalUrl}`);
+      }
     }
   } else {
     // For relative URLs
@@ -103,12 +125,16 @@ export function getOptimizedImageUrl(url: string | null): string {
       // URL has leading slash like "/media/..."
       const baseUrl = isServer ? 'http://django:8000' : 'http://localhost:8000';
       finalUrl = `${baseUrl}${finalUrl}`;
-      console.log(`[getOptimizedImageUrl] Added base URL to path with leading slash: ${finalUrl}`);
+      if (isDev) {
+        console.log(`[getOptimizedImageUrl] Added base URL to path with leading slash: ${finalUrl}`);
+      }
     } else {
       // URL has no leading slash
       const baseUrl = isServer ? 'http://django:8000/' : 'http://localhost:8000/';
       finalUrl = `${baseUrl}${finalUrl}`;
-      console.log(`[getOptimizedImageUrl] Added base URL to path without leading slash: ${finalUrl}`);
+      if (isDev) {
+        console.log(`[getOptimizedImageUrl] Added base URL to path without leading slash: ${finalUrl}`);
+      }
     }
   }
   
@@ -124,7 +150,9 @@ export function getOptimizedImageUrl(url: string | null): string {
     finalUrl += (finalUrl.includes('?') ? '&' : '?') + 'fm=webp';
   }
   
-  console.log(`[getOptimizedImageUrl] Final URL: ${finalUrl}`);
+  if (isDev) {
+    console.log(`[getOptimizedImageUrl] Final URL: ${finalUrl}`);
+  }
   return finalUrl;
 }
 
@@ -139,18 +167,24 @@ export function getOptimizedImageUrl(url: string | null): string {
  */
 export function getPublicImageUrl(url: string | null): string {
   if (!url) return '';
-  
-  console.log(`[getPublicImageUrl] Processing URL: ${url}`);
+
+  if (isDev) {
+    console.log(`[getPublicImageUrl] Processing URL: ${url}`);
+  }
   
   // Fix any malformed URL protocols first (missing double slash)
   let fixedUrl = url;
   if (url.includes('https:/') && !url.includes('https://')) {
     fixedUrl = url.replace(/https:\/([^\/])/g, 'https://$1');
-    console.log(`[getPublicImageUrl] Fixed malformed https URL: ${url} -> ${fixedUrl}`);
+    if (isDev) {
+      console.log(`[getPublicImageUrl] Fixed malformed https URL: ${url} -> ${fixedUrl}`);
+    }
   }
   if (url.includes('http:/') && !url.includes('http://')) {
     fixedUrl = url.replace(/http:\/([^\/])/g, 'http://$1');
-    console.log(`[getPublicImageUrl] Fixed malformed http URL: ${url} -> ${fixedUrl}`);
+    if (isDev) {
+      console.log(`[getPublicImageUrl] Fixed malformed http URL: ${url} -> ${fixedUrl}`);
+    }
   }
   
   // If it's already an absolute URL from a public source (like Picsum)
@@ -158,23 +192,31 @@ export function getPublicImageUrl(url: string | null): string {
     // Check if it's an external URL that needs decoding
     if (fixedUrl.includes('%3A') || fixedUrl.includes('%2F')) {
       let decodedUrl = decodeURIComponent(fixedUrl);
-      console.log(`[getPublicImageUrl] Decoded URL: ${fixedUrl} -> ${decodedUrl}`);
+      if (isDev) {
+        console.log(`[getPublicImageUrl] Decoded URL: ${fixedUrl} -> ${decodedUrl}`);
+      }
       fixedUrl = decodedUrl;
       
       // Check again for malformed URLs after decoding
       if (fixedUrl.includes('https:/') && !fixedUrl.includes('https://')) {
         let newFixedUrl = fixedUrl.replace(/https:\/([^\/])/g, 'https://$1');
-        console.log(`[getPublicImageUrl] Fixed malformed https URL after decoding: ${fixedUrl} -> ${newFixedUrl}`);
+        if (isDev) {
+          console.log(`[getPublicImageUrl] Fixed malformed https URL after decoding: ${fixedUrl} -> ${newFixedUrl}`);
+        }
         fixedUrl = newFixedUrl;
       }
       if (fixedUrl.includes('http:/') && !fixedUrl.includes('http://')) {
         let newFixedUrl = fixedUrl.replace(/http:\/([^\/])/g, 'http://$1');
-        console.log(`[getPublicImageUrl] Fixed malformed http URL after decoding: ${fixedUrl} -> ${newFixedUrl}`);
+        if (isDev) {
+          console.log(`[getPublicImageUrl] Fixed malformed http URL after decoding: ${fixedUrl} -> ${newFixedUrl}`);
+        }
         fixedUrl = newFixedUrl;
       }
     }
     
-    console.log(`[getPublicImageUrl] Final URL: ${fixedUrl}`);
+    if (isDev) {
+      console.log(`[getPublicImageUrl] Final URL: ${fixedUrl}`);
+    }
     return fixedUrl;
   }
   

--- a/frontend/pages/posts/[slug].tsx
+++ b/frontend/pages/posts/[slug].tsx
@@ -10,6 +10,8 @@ import remarkGfm from 'remark-gfm';
 import SocialShare from '../../components/SocialShare';
 import { getOptimizedImageUrl, getPublicImageUrl, getCanonicalUrl } from '../../lib/utils';
 
+const isDev = process.env.NODE_ENV === 'development';
+
 interface PostPageProps {
   post: Post | null;
 }
@@ -26,24 +28,28 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   if (!post) {
     return { notFound: true };
   }
-  console.log(`[SSR] Post ${slug} data:`, { 
-    id: post.id, 
-    featured_image: post.featured_image,
-    side_image_1: post.side_image_1,
-    side_image_2: post.side_image_2
-  });
+  if (isDev) {
+    console.log(`[SSR] Post ${slug} data:`, {
+      id: post.id,
+      featured_image: post.featured_image,
+      side_image_1: post.side_image_1,
+      side_image_2: post.side_image_2
+    });
+  }
   return { props: { post } };
 };
 
 const PostPage: React.FC<PostPageProps> = ({ post }) => {
   useEffect(() => {
     if (post) {
-      console.log(`[PostPage] Client-side, Post ${post.id} - ${post.title}`);
-      console.log(`[PostPage] Original image URLs:`, {
-        featured: post.featured_image,
-        side1: post.side_image_1,
-        side2: post.side_image_2
-      });
+      if (isDev) {
+        console.log(`[PostPage] Client-side, Post ${post.id} - ${post.title}`);
+        console.log(`[PostPage] Original image URLs:`, {
+          featured: post.featured_image,
+          side1: post.side_image_1,
+          side2: post.side_image_2
+        });
+      }
     }
   }, [post]);
 
@@ -55,30 +61,36 @@ const PostPage: React.FC<PostPageProps> = ({ post }) => {
     day: 'numeric',
   });
 
-  console.log(`[PostPage] Server-side or Hydration, Post ${post.id} - ${post.title}`);
-  console.log('[PostPage] Getting optimized image URLs');
+  if (isDev) {
+    console.log(`[PostPage] Server-side or Hydration, Post ${post.id} - ${post.title}`);
+    console.log('[PostPage] Getting optimized image URLs');
+  }
 
   // Get optimized image URLs for rendering in the page
   const optimizedFeaturedImage = getOptimizedImageUrl(post.featured_image);
   const optimizedSideImage1 = getOptimizedImageUrl(post.side_image_1 || null);
   const optimizedSideImage2 = getOptimizedImageUrl(post.side_image_2 || null);
 
-  console.log('[PostPage] Optimized image URLs:', {
-    featured: optimizedFeaturedImage,
-    side1: optimizedSideImage1,
-    side2: optimizedSideImage2
-  });
+  if (isDev) {
+    console.log('[PostPage] Optimized image URLs:', {
+      featured: optimizedFeaturedImage,
+      side1: optimizedSideImage1,
+      side2: optimizedSideImage2
+    });
+  }
 
   // Get proper public URLs for meta tags
   const metaFeaturedImage = getPublicImageUrl(post.featured_image);
   const metaSideImage1 = getPublicImageUrl(post.side_image_1 || null);
   const metaSideImage2 = getPublicImageUrl(post.side_image_2 || null);
 
-  console.log('[PostPage] Meta tag image URLs:', {
-    featured: metaFeaturedImage,
-    side1: metaSideImage1,
-    side2: metaSideImage2
-  });
+  if (isDev) {
+    console.log('[PostPage] Meta tag image URLs:', {
+      featured: metaFeaturedImage,
+      side1: metaSideImage1,
+      side2: metaSideImage2
+    });
+  }
 
   // Canonical URL for this post
   const canonicalUrl = getCanonicalUrl(`/posts/${post.slug}`);


### PR DESCRIPTION
## Summary
- guard console statements with environment checks in frontend

## Testing
- `npm run lint` *(fails: no-useless-escape etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68419b40c0e8832c9fb6d61f8e9d3a61