### PR TITLE
Add rehype-sanitize to markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A modern, minimalist blog template built with Django, Docker, and Next.js. The t
 - Redis for caching
 - Celery for background tasks
 - Markdown support for content creation
+- Sanitized Markdown rendering with `rehype-sanitize`
 - Dark/light mode toggle
 - Featured posts management
 - Newsletter subscription

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^9.0.1",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "swr": "^2.2.4"
       },
@@ -630,14 +631,12 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.20",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1874,7 +1873,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3435,6 +3433,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-to-jsx-runtime": {
@@ -6075,6 +6088,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^9.0.1",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "swr": "^2.2.4"
   },

--- a/frontend/pages/posts/[slug].tsx
+++ b/frontend/pages/posts/[slug].tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
 import SocialShare from '../../components/SocialShare';
 import { getOptimizedImageUrl, getPublicImageUrl, getCanonicalUrl } from '../../lib/utils';
 
@@ -229,7 +230,7 @@ const PostPage: React.FC<PostPageProps> = ({ post }) => {
               return (
                 <>
                   {/* First segment */}
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} className="prose dark:prose-invert max-w-none mb-6">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]} className="prose dark:prose-invert max-w-none mb-6">
                     {part1}
                   </ReactMarkdown>
                   {/* First side image */}
@@ -247,7 +248,7 @@ const PostPage: React.FC<PostPageProps> = ({ post }) => {
                     </div>
                   )}
                   {/* Second segment */}
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} className="prose dark:prose-invert max-w-none mb-6">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]} className="prose dark:prose-invert max-w-none mb-6">
                     {part2}
                   </ReactMarkdown>
                   {/* Second side image */}
@@ -265,7 +266,7 @@ const PostPage: React.FC<PostPageProps> = ({ post }) => {
                     </div>
                   )}
                   {/* Final segment */}
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} className="prose dark:prose-invert max-w-none mb-6">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]} className="prose dark:prose-invert max-w-none mb-6">
                     {part3}
                   </ReactMarkdown>
                 </>


### PR DESCRIPTION
## Summary
- install `rehype-sanitize`
- sanitize markdown in post pages
- document sanitization in the README

## Testing
- `npm run lint` *(fails: no-useless-escape and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68419b3d1f8c832caa45782dafc47975